### PR TITLE
UI patches

### DIFF
--- a/src/ui/components/Customizer/SetupInstructions.jsx
+++ b/src/ui/components/Customizer/SetupInstructions.jsx
@@ -56,10 +56,10 @@ const BasicSetupInstructions = props => {
     <a href="https://adoptium.net/" target="_blank">https://adoptium.net/</a>.
 <br /><br />
 <h5>Setup</h5>
-    Download the binary distribution to a file from 
+    Download the binary distribution to a file from&nbsp;
     <a href="https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar" target="_blank">
-    https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar</a> . 
-    This guide assumes the name is left as the default: 
+    https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar</a>.
+    This guide assumes the name is left as the default:&nbsp;
     <code>synthea-with-dependencies.jar</code>.
 
     { keepModuleString && (<div>
@@ -69,9 +69,10 @@ const BasicSetupInstructions = props => {
 <br /><br />
 <h5>Running</h5>
     Open a command-line prompt/terminal window and run Synthea 
-    by running the command below with your specified configuration as arguments: <br/>
-    <BashCodeBlock code={renderArgs('java -jar synthea-with-dependencies.jar', myArgs, config)} />. <br/>
-
+    by running the command below with your specified configuration as arguments:
+    <br/>
+    <BashCodeBlock code={renderArgs('java -jar synthea-with-dependencies.jar', myArgs, config)} />
+    <br />
 
 </div>);
 }

--- a/src/ui/components/Dashboard/styles.jsx
+++ b/src/ui/components/Dashboard/styles.jsx
@@ -106,7 +106,9 @@ export default makeStyles(
       color: theme.palette.common.grayVeryDark
     },
     overflow: {
-      overflowY: 'scroll'
+      overflowY: 'scroll',
+      scrollbarWidth: 'thin',
+      scrollbarColor: `${theme.palette.common.grayVeryLight} ${theme.palette.common.grayVeryDark}`
     },
     searchInput: {
       '&::placeholder': {

--- a/src/ui/components/PatientViewer/PatientViewer.jsx
+++ b/src/ui/components/PatientViewer/PatientViewer.jsx
@@ -76,7 +76,7 @@ const getDropzone = (setLoading, callback) => {
             >
               <Box sx={{ p: 2, border: '1px dashed grey', textAlign: 'center' }}>
                 <h2>Drag &amp; drop a FHIR JSON file here</h2>
-                <h2>or click to select a file.</h2>
+                <h2>or <span style={{textDecoration: 'underline', color: 'blue'}}>click to select a file</span>.</h2>
               </Box>
             </Box>
           </div>

--- a/src/ui/components/PatientViewer/PatientViewer.jsx
+++ b/src/ui/components/PatientViewer/PatientViewer.jsx
@@ -473,7 +473,7 @@ const EncounterGroupedRecord = props => {
   return (
     <React.Fragment>
       <LinksByEncounter encounters={encounters} />
-      <Accordion allowMultipleExpanded={true}>{encounterSections}</Accordion>;
+      <Accordion allowMultipleExpanded={true}>{encounterSections}</Accordion>
     </React.Fragment>
   );
 };

--- a/src/ui/components/app.css
+++ b/src/ui/components/app.css
@@ -22,6 +22,11 @@ pre {
 
 /* sets BashCodeBlock color, required to overright some upstream css library */
 span code span, span code {
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !important;
     font-size: 1.05rem;
     color: #ecf8ff !important;
+}
+
+code {
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !important;
 }


### PR DESCRIPTION
 - remove the stray '.' in basic setup
 - add `<code>` font family
 - add mock link styling to 'click to select a file' in PatientViewer
 - remove stray ';' in PatientViewer
 - attempt to fix scrollbar-sidebar glitch by specifying scrollbar styling. I'm not sure if this fixes it because I can't reproduce the issue, but either way it does not affect functionality.