### PR TITLE
Support MedicationRequest.medicationReference

### DIFF
--- a/src/ui/components/PatientViewer/PatientViewer.jsx
+++ b/src/ui/components/PatientViewer/PatientViewer.jsx
@@ -228,6 +228,16 @@ const EntireRecord = props => {
   const getByType = type => allResources.filter(r => r.resourceType === type);
   const conditions = getByType('Condition');
   const medications = getByType('MedicationRequest');
+  const meds = getByType('Medication');
+  medications.forEach(m => {
+    if (m.medicationReference) {
+      const referencedMed = meds.find(med => isMatchingReference(med, m.medicationReference.reference, 'Medication'));
+      if (referencedMed) {
+        m.medicationCodeableConcept = referencedMed.code;
+      }
+    }
+  });
+
   let observations = getByType('Observation');
   const reports = getByType('DiagnosticReport');
 


### PR DESCRIPTION
Quick hack to support MedicationRequests that point to a Medication resource via `medicationReference` instead of specifying the code directly. The hack is to look up the Medication resource and store its `code` as the `medicationCodeableConcept` on the MedicationRequest