### PR TITLE
Rebuild Keep module after toggling all/any

### DIFF
--- a/src/ui/components/Customizer/KeepModuleBuilder.jsx
+++ b/src/ui/components/Customizer/KeepModuleBuilder.jsx
@@ -57,19 +57,13 @@ const setConditionType = (m, type) => m['states']['Initial']['conditional_transi
 const clone = obj => JSON.parse(JSON.stringify(obj)); // simple deep copy to make sure a template never changes
 
 const buildKeepModule = (keeps, any) => {
-
   const keepModule = clone(KEEP_TEMPLATE); 
-
   setConditionType(keepModule, any ? "Or" : "And")
-
   const keepConditions = getConditions(keepModule);
-
   for (const keep of keeps) {
     // keep = { type, value }
 
     const newCondition = clone(CONDITION_TEMPLATE);
-
-
     newCondition['codes'][0] = keep.value;
 
     switch (keep.type) {
@@ -88,9 +82,7 @@ const buildKeepModule = (keeps, any) => {
       // we can use Active Condition instead
       newCondition['condition_type'] = 'Active Condition';
       break;
-
     }
-
 
     keepConditions.push(newCondition);
   }
@@ -108,6 +100,11 @@ const KeepModuleBuilder = (props) => {
   const [value, setValue] = useState('');
 
   const { setKeepModuleString, showDownload } = props;
+
+  const setAnyAndRebuildModule = (value) => {
+    setAny(value);
+    setKeepModuleString(buildKeepModule(keeps, value));
+  };
 
   const handleChange = () => {};
   const addCurrent = () => {
@@ -160,7 +157,7 @@ const KeepModuleBuilder = (props) => {
 
       <br />
 
-      ALL OF <Switch onChange={e => setAny(e.target.checked)} /> ANY OF <br />
+      ALL OF <Switch onChange={e => setAnyAndRebuildModule(e.target.checked)} /> ANY OF <br />
 
       <div>Keep patients matching <b>{ any ? "Any" : "All" }</b> of the following criteria:</div>
       <ul>


### PR DESCRIPTION
Addresses #19 - Rebuilds the Keep Module after toggling the Any Of/All Of switch.

To Reproduce (from linked issue):

- Start with the ALL OF / ANY OF toggle set to ALL OF.
- Define some set of Keep Module Builder criteria (e.g. add some active conditions)
- Download the Keep.json file and inspect it: default state should have states.Initial.conditional_transition[0].condition.condition_type == 'And'
- Return to the Keep Module Builder and toggle the ALL OF / ANY OF to the ANY OF state.
- Download the Keep.json file and inspect it: states.Initial.conditional_transition[0].condition.condition_type should now be "Or"; previously it was stuck on "And"

Note this doesn't add any debounce as suggested in the issue, that's something to tackle when we have more time 