### PR TITLE
Feature: support for uploading GZIP bundles of patient data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 
 # https://github.com/facebook/create-react-app/issues/6560
 src/*.d.ts
+
+# Local data directory
+data/

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "morgan": "~1.9.1",
         "node-jose": "^2.0.0",
         "nodemon": "^2.0.7",
+        "pako": "^2.1.0",
         "prop-types": "^15.7.2",
         "query-string": "^6.13.8",
         "react": "^18.0.0",
@@ -118,6 +119,7 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -2017,6 +2019,7 @@
       "version": "11.11.4",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
       "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -2057,6 +2060,7 @@
       "version": "11.11.5",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
       "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -3130,6 +3134,7 @@
       "version": "5.13.5",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.13.5.tgz",
       "integrity": "sha512-eMay+Ue1OYXOFMQA5Aau7qbAa/kWHLAyi0McsbPTWssCbGehqkF6CIdPsfVGw6tlO+xPee1hUitphHJNL3xpOQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0",
         "@mui/base": "5.0.0-beta.4",
@@ -3379,6 +3384,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3475,6 +3481,7 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.1.tgz",
       "integrity": "sha512-vRb792M4mF1FBT+eoLecmkpLXwxsBHvWWRGJjzbYANBM6DtiJc6yETyv4rqDA6QNjF1pkj1U7LMA6dGb3VYlHw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3575,6 +3582,7 @@
       "version": "18.2.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.11.tgz",
       "integrity": "sha512-+hsJr9hmwyDecSMQAmX7drgbDpyE+EgSF6t7+5QEBAn1tQK7kl1vWZ4iRf6SjQ8lk7dyEULxUmZOIpN0W5baZA==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3868,6 +3876,7 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3941,6 +3950,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4672,6 +4682,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001503",
         "electron-to-chromium": "^1.4.431",
@@ -6103,6 +6114,7 @@
       "version": "8.45.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
       "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -10350,7 +10362,8 @@
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "peer": true
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -11524,7 +11537,8 @@
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -11722,6 +11736,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -11821,6 +11836,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
       "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12103,6 +12119,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12172,6 +12189,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12301,6 +12319,7 @@
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.2.tgz",
       "integrity": "sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.7.2",
         "react-router": "6.14.2"
@@ -15128,6 +15147,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.86.0.tgz",
       "integrity": "sha512-3BOvworZ8SO/D4GVP+GoRC3fVeg5MO4vzmq8TJJEkdmopxyazGDxN8ClqN12uzrZW9Tv8EED8v5VSb6Sqyi0pg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -15175,6 +15195,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -15251,6 +15272,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "morgan": "~1.9.1",
     "node-jose": "^2.0.0",
     "nodemon": "^2.0.7",
+    "pako": "^2.1.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.13.8",
     "react": "^18.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ app.use(express.json());
 app.use(bodyParser.json({ type: ['application/json', 'application/fhir+json'] }));
 
 // Routes for collections
-Object.values(collections).forEach(collectionName => {
+Object.values(collections).forEach((collectionName) => {
   app.use(`/collection/${collectionName}`, genericController(collectionName));
 });
 

--- a/src/handlers/crudHandler.js
+++ b/src/handlers/crudHandler.js
@@ -20,16 +20,16 @@ function isMatch(object, attrs) {
 }
 
 function getHandler(collectionName, req, res) {
-  const result = db.select(collectionName, row => isMatch(row, req.query));
+  const result = db.select(collectionName, (row) => isMatch(row, req.query));
   res.send(result);
 }
 
 function updateHandler(collectionName, req, res) {
   const changedItem = req.body;
-  if (req.query.id) db.upsert(collectionName, changedItem, r => r.id === req.query.id);
+  if (req.query.id) db.upsert(collectionName, changedItem, (r) => r.id === req.query.id);
   else if (req.query.fullUrl) {
     const fullUrl = base64url.decode(req.query.fullUrl);
-    db.upsert(collectionName, changedItem, r => r.fullUrl === fullUrl);
+    db.upsert(collectionName, changedItem, (r) => r.fullUrl === fullUrl);
   } else {
     res.send('Must include id or fullUrl').status(StatusCodes.BAD_REQUEST);
     return;
@@ -40,10 +40,10 @@ function updateHandler(collectionName, req, res) {
 
 function deleteHandler(collectionName, req, res) {
   if (req.query.id) {
-    db.delete(collectionName, r => r.id === req.query.id);
+    db.delete(collectionName, (r) => r.id === req.query.id);
   } else if (req.query.fullUrl) {
     const fullUrl = base64url.decode(req.query.fullUrl);
-    db.delete(collectionName, r => r.fullUrl === fullUrl);
+    db.delete(collectionName, (r) => r.fullUrl === fullUrl);
   } else {
     res.send('Must include id or fullUrl').status(StatusCodes.BAD_REQUEST);
     return;

--- a/src/storage/collections.js
+++ b/src/storage/collections.js
@@ -14,5 +14,5 @@ module.exports = {
   PAYERS: 'payers',
   PROCEDURES: 'procedures',
   PROVIDERS: 'providers',
-  SUPPLIES: 'supplies'
+  SUPPLIES: 'supplies',
 };

--- a/src/storage/logs.js
+++ b/src/storage/logs.js
@@ -4,14 +4,14 @@ const debugConsole = require('debug');
 const { v4: uuidv4 } = require('uuid');
 
 function debug(location) {
-  return message => {
+  return (message) => {
     const logger = debugConsole(location);
     logger(message);
     const log = {
       id: uuidv4(),
       timestamp: Date.now(),
       message: message,
-      location: location
+      location: location,
     };
     db.insert(LOGS, log);
   };
@@ -25,7 +25,7 @@ function error(location) {
       id: uuidv4(),
       timestamp: Date.now(),
       error: error,
-      location: location
+      location: location,
     };
     db.insert(ERRORS, log);
 
@@ -34,7 +34,7 @@ function error(location) {
       timestamp: Date.now(),
       notif: notif || error,
       viewed: false,
-      type: 'error'
+      type: 'error',
     };
     db.insert(NOTIFICATIONS, notification);
   };
@@ -46,7 +46,7 @@ function storeRequest(request) {
     timestamp: Date.now(),
     url: request.url,
     body: request.body,
-    headers: request.headers
+    headers: request.headers,
   };
   db.insert(REQUESTS, log);
 }


### PR DESCRIPTION
Hi Synthea Team! 

We're looking at using the SPT patient viewer (and the FHIR visualizers therein) as a quick way of uploading bundles of FHIR data to a webpage to view them in a more reasonable manner than poking around a giant JSON bundle/collection of NDJSON. However, our workflows leverage a lot of gzipped data. To support that usecase, I added the `pako` package (I thought about using the [DecompressionStream API](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream) but was having issues getting that running on Node/certainly wouldn't expect it to run on package.json's recommended Node >= v14. 

Anyway, I wanted to pay this small PR forward incase your team was interested in adding this new package/feature into the true SPT project. 

P.S. Most of the changes are just eslint rules being applied; the meat of the change occurs in `src/ui/components/PatientViewer/PatientViewer.jsx`, specifically in the DropZone event handler you define. 

Thanks,
- Dylan P. 